### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -2,6 +2,9 @@ name: Lint & Format
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rodrinac/cinemaclub/security/code-scanning/2](https://github.com/rodrinac/cinemaclub/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/pull_requests.yml` at the workflow root, immediately after the `on` section, so all jobs inherit least-privilege settings unless overridden.  
For this lint/format workflow, the minimal and appropriate permission is:

- `contents: read`

This preserves existing functionality (`actions/checkout` and reading repo files) while preventing unintended write scopes on `GITHUB_TOKEN`. No imports, methods, or external definitions are needed—just YAML workflow configuration update in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
